### PR TITLE
Remove custom reporter for typescript errors

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -14,4 +14,4 @@ jobs:
           yarn set version 4.1.1
       - name: Yarn Install
         run: yarn install --frozen-lockfile
-      - uses: andoshin11/typescript-error-reporter-action@v1.0.2
+      - run: yarn tchk

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dist"
   ],
   "scripts": {
+    "tchk": "tsc --noEmit",
     "build": "tsup",
     "prepublish": "yarn build",
     "lint": "yarn build && eslint lib .prettierrc.js eslint.config.js",


### PR DESCRIPTION
The CI errors are pretty silly and not helpful